### PR TITLE
feat: option to use dates instead of span for selecting time

### DIFF
--- a/src/OTUanalysis.jl
+++ b/src/OTUanalysis.jl
@@ -52,6 +52,8 @@ date_col = "datetime" # The name of the column containing the datetime.
 id_col = "OTU_ID" # The name of the column containing the OTU IDs.
 sampling_date_west = "23.07.2023 11:00" # The date at which the samples were taken in the western study region.
 sampling_date_east = "22.07.2023 11:00" # The date at which the samples were taken in the eastern study region.
+start_date = "" # e.g."01.01.2022 12:00" # Oprional! The start date of the analysis. If set, span will be ignored. Format: "dd.mm.yyyy HH:MM"
+end_date = "" # e.g. "01.01.2023 12:00" # Optional! The end date of the analysis. If not set, the sampling date will be used. Format: "dd.mm.yyyy HH:MM"
 
 plot = true # If true, plots are generated.
 plot_pdf = true # If true, plots are saved as pdf.
@@ -89,9 +91,9 @@ end
 # plsr
 results = Dict()
 for otu_id in otu_ids
-    results[otu_id] = get_selectivity_ratio(df_env, df_dna, cdna, otu_id, span, step, n_folds, date_col, id_col, sampling_date_west, sampling_date_east, env_var, season, smooth, plot, plot_pdf, plot_png, countRange, saveFrequencies, plot_type, sig_niveau)
+    results[otu_id] = get_selectivity_ratio(df_env, df_dna, cdna, otu_id, span, step, n_folds, date_col, id_col, sampling_date_west, sampling_date_east, start_date, end_date, env_var, season, smooth, plot, plot_pdf, plot_png, countRange, saveFrequencies, plot_type, sig_niveau)
     if random_forest
-        random_forest_importance(df_env, df_dna, cdna, otu_id, span, date_col, id_col, sampling_date_west, sampling_date_east, season, plot, plot_pdf, plot_png, group_by)
+        random_forest_importance(df_env, df_dna, cdna, otu_id, span, date_col, id_col, sampling_date_west, sampling_date_east, start_date, end_date, season, plot, plot_pdf, plot_png, group_by)
     end
 end
 

--- a/src/plsr.jl
+++ b/src/plsr.jl
@@ -3,7 +3,7 @@ function remove_constant_columns(df::DataFrame)
     return df[:, non_constant_columns]
 end
 
-function get_selectivity_ratio(df::DataFrame, df_otu::DataFrame, cdna::Bool, otu_id::String, span::Number, step::Number, n_folds::Number, date_col::String, id_col::String, sampling_date_west::String, sampling_date_east::String, env_var::String, season::String="all", smooth::Number=0.2, plot=true, plot_pdf::Bool=false, plot_png::Bool=false, countRange::Bool=true, saveFrequencies::Bool=true, plot_type::String="all", sig_niveau::Number=0.1)
+function get_selectivity_ratio(df::DataFrame, df_otu::DataFrame, cdna::Bool, otu_id::String, span::Number, step::Number, n_folds::Number, date_col::String, id_col::String, sampling_date_west::String, sampling_date_east::String, start_date::String, end_date::String, env_var::String, season::String="all", smooth::Number=0.2, plot=true, plot_pdf::Bool=false, plot_png::Bool=false, countRange::Bool=true, saveFrequencies::Bool=true, plot_type::String="all", sig_niveau::Number=0.1)
     """
     Trunctuates a Dataframe with a datetime column to a specific sub-dataframe.
 
@@ -19,6 +19,8 @@ function get_selectivity_ratio(df::DataFrame, df_otu::DataFrame, cdna::Bool, otu
     - id_col::String: Name of the column containing the otu ids.
     - sampling_date_west::String: Date at which the samples were taken in the west.
     - sampling_date_east::String: Date at which the samples were taken in the west.
+    - start_date::String: Optional, the start date of the analysis. If set, span will be ignored.
+    - end_date::String: Optional, the end date of the analysis. If not set, the sampling date will be used.
     - env_var::String: environmental variable to process (either "AT", "ST", "SM")
     - season::String: Optional, the meteorolocical season which should be included. Includes all seasons if not set.
     - smooth::Number: Optional, level of smoothing (between 0 and 1), default is 0.2.
@@ -34,7 +36,7 @@ function get_selectivity_ratio(df::DataFrame, df_otu::DataFrame, cdna::Bool, otu
     - DataFrame: DataFrame containing selectivity ratios (sel_ratio) with significance (significance), p-value (pval), environmental value (x), and smoothed selectivity ratio for plotting (sel_ratio_smooth).
     """
 
-    df_processed = prepare_data(df, df_otu, cdna, otu_id, span, step, date_col, id_col, sampling_date_west, sampling_date_east, env_var, season, countRange, saveFrequencies)
+    df_processed = prepare_data(df, df_otu, cdna, otu_id, span, step, date_col, id_col, sampling_date_west, sampling_date_east, start_date, end_date, env_var, season, countRange, saveFrequencies)
     df_cleaned = dropmissing(select(df_processed, Not(:position)))
 
     X = remove_constant_columns(df_cleaned[:, Not(:values)])


### PR DESCRIPTION
This adds the option to define the timespan to be included into the analysis by specific start and end dates instead of the sampling date and a span.